### PR TITLE
[INTGHUB-7] Atualizar exemplo de Monitor para as notificações de eventos de pendrive

### DIFF
--- a/Controle de Acesso/Exemplo API Monitor - NodeJS/app.js
+++ b/Controle de Acesso/Exemplo API Monitor - NodeJS/app.js
@@ -113,6 +113,14 @@ app.post('/api/notifications/user_image', function (req, res) {
   res.status(200).send();
 })
 
+// Notification usb drive
+app.post('/api/notifications/usb_drive', function (req, res) {
+  console.log("endpoint: API/NOTIFICATIONS/USB_DRIVE");
+  console.log(req.body);
+  console.log("\n");
+  res.status(200).send();
+})
+
 // Device and server IP address
 var deviceIp = '192.168.0.129';
 async function configureMonitorTest(serverIp, serverPort) {


### PR DESCRIPTION
Adicionado código que exibe um exemplo de monitor para notificações de eventos de log de auditoria de usb_drive

Tarefa: [INTGHUB-7: Atualizar exemplo de Monitor para as notificações de eventos de pendrive.](https://controlid.atlassian.net/browse/INTGHUB-7)

Implementação:

    INTGHUB-7: master -controlid/integracao

Dependência:

    Nenhuma